### PR TITLE
Trigger frameIndexChanged when current frame changes

### DIFF
--- a/src/threesixty.js
+++ b/src/threesixty.js
@@ -499,6 +499,7 @@
         base.hidePreviousFrame();
         AppCongif.currentFrame += frameEasing;
         base.showCurrentFrame();
+        base.$el.trigger('frameIndexChanged', [base.getNormalizedCurrentFrame(), AppCongif.totalFrames]);
       } else {
         window.clearInterval(AppCongif.ticker);
         AppCongif.ticker = 0;


### PR DESCRIPTION
This can be used for custom logic, e.g. showing a slider with current frame or updating other parts of UI, in sync with the rotation.

I can also update docs if the patch looks fine.
